### PR TITLE
Update YOLO deployment script

### DIFF
--- a/src/edge/deployment.yolov3.template.json
+++ b/src/edge/deployment.yolov3.template.json
@@ -81,7 +81,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/ava-utilities/avaextension/http-yolov3-onnx-v1.0",
+              "image": "mcr.microsoft.com/ava-utilities/avaextension:http-yolov3-onnx-v1.0",
               "createOptions": {}
             }
           },


### PR DESCRIPTION
There should have been colons (:) after `avaextension` instead of a slash (/).